### PR TITLE
fix: Update firestore class to accept the databaseId from the configuration file

### DIFF
--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -423,6 +423,7 @@ class StateFirestore extends State {
     super(cluster);
     this.stateDatabase = cluster.stateDatabase;
     /** @type {firestore.Firestore} */
+    // @ts-ignore
     this.firestore = StateFirestore.getFirestoreClient(this.stateProjectId, this.stateDatabase);
   }
 

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -390,6 +390,9 @@ class StateFirestore extends State {
    * @return {firestore.Firestore}
    */
   static createFirestoreClient(stateProjectId, stateDatabase) {
+    if (!stateDatabase.databaseId) {
+      return new firestore.Firestore({projectId: stateProjectId, databaseId: "(default)"});
+    }
     return new firestore.Firestore({projectId: stateProjectId, databaseId: stateDatabase.databaseId});
   }
 
@@ -400,6 +403,9 @@ class StateFirestore extends State {
    * @return {string}
    */
    static getStateDatabasePath(stateProjectId, stateDatabase) {
+    if (!stateDatabase.databaseId) {
+      return `projects/${stateProjectId}/databases/(default)`;
+    }
     return `projects/${stateProjectId}/databases/${stateDatabase.databaseId}`;
   }
 

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -390,24 +390,17 @@ class StateFirestore extends State {
    * @return {firestore.Firestore}
    */
   static createFirestoreClient(stateProjectId, stateDatabase) {
-    let databaseId = stateDatabase.databaseId;
-    if (!databaseId) {
-      databaseId = "(default)";
-    }
-    return new firestore.Firestore({projectId: stateProjectId, databaseId: databaseId});
+    return new firestore.Firestore({projectId: stateProjectId, databaseId: stateDatabase.databaseId});
   }
 
   /**
-   * Get the ID of the database from the stateDatabase configuration
+   * Builds a Firestore database path - used as the key for memoize
+   * @param {string} stateProjectId
    * @param {StateDatabaseConfig} stateDatabase
    * @return {string}
    */
-   static getDatabaseId(stateDatabase) {
-    let databaseId = stateDatabase.databaseId;
-    if (!databaseId) {
-      databaseId = "(default)";
-    }
-    return databaseId;
+   static getStateDatabasePath(stateProjectId, stateDatabase) {
+    return `projects/${stateProjectId}/databases/${stateDatabase.databaseId}`;
   }
 
   /**
@@ -423,8 +416,9 @@ class StateFirestore extends State {
    */
   constructor(cluster) {
     super(cluster);
-    this.stateDabase = cluster.stateDatabase;
-    this.firestore = StateFirestore.getFirestoreClient(this.stateProjectId, this.stateDabase);
+    this.stateDatabase = cluster.stateDatabase;
+    /** @type {firestore.Firestore} */
+    this.firestore = StateFirestore.getFirestoreClient(this.stateProjectId, this.stateDatabase);
   }
 
   /**

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Copyright 2024 Google LLC
  *

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -414,7 +414,7 @@ class StateFirestore extends State {
    * client for each stateProject
    */
   static getFirestoreClient = memoize(
-    StateFirestore.createFirestoreClient, StateFirestore.getDatabasePath
+    StateFirestore.createFirestoreClient, StateFirestore.getStateDatabasePath
   );
 
   /**

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Copyright 2024 Google LLC
  *
@@ -376,7 +377,8 @@ class StateSpanner extends State {
  *
  * {
  *   "stateDatabase": {
- *       "name": "firestore"
+ *       "name": "firestore",
+ *       "databaseId": "(default)"
  *   }
  * }
  */
@@ -384,10 +386,15 @@ class StateFirestore extends State {
   /**
    * Builds a Firestore client for the given project ID
    * @param {string} stateProjectId
+   * @param {StateDatabaseConfig} stateDatabase
    * @return {firestore.Firestore}
    */
-  static createFirestoreClient(stateProjectId) {
-    return new firestore.Firestore({projectId: stateProjectId});
+  static createFirestoreClient(stateProjectId, stateDatabase) {
+    let databaseId = stateDatabase.databaseId;
+    if (!databaseId) {
+      databaseId = "(default)";
+    }
+    return new firestore.Firestore({projectId: stateProjectId, databaseId: databaseId});
   }
 
   /**
@@ -401,7 +408,7 @@ class StateFirestore extends State {
    */
   constructor(cluster) {
     super(cluster);
-    this.firestore = StateFirestore.getFirestoreClient(this.stateProjectId);
+    this.firestore = StateFirestore.getFirestoreClient(this.stateProjectId, cluster.stateDatabase);
   }
 
   /**

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -414,7 +414,7 @@ class StateFirestore extends State {
    * client for each stateProject
    */
   static getFirestoreClient = memoize(
-    StateFirestore.createFirestoreClient, StateFirestore.getDatabaseId
+    StateFirestore.createFirestoreClient, StateFirestore.getDatabasePath
   );
 
   /**

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -408,7 +408,7 @@ class StateFirestore extends State {
    */
   constructor(cluster) {
     super(cluster);
-    this.stateDabase = cluster.stateDatabase
+    this.stateDabase = cluster.stateDatabase;
     this.firestore = StateFirestore.getFirestoreClient(this.stateProjectId, this.stateDabase);
   }
 

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -408,7 +408,8 @@ class StateFirestore extends State {
    */
   constructor(cluster) {
     super(cluster);
-    this.firestore = StateFirestore.getFirestoreClient(this.stateProjectId, cluster.stateDatabase);
+    this.stateDabase = cluster.stateDatabase
+    this.firestore = StateFirestore.getFirestoreClient(this.stateProjectId, this.stateDabase);
   }
 
   /**

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -398,10 +398,25 @@ class StateFirestore extends State {
   }
 
   /**
+   * Get the ID of the database from the stateDatabase configuration
+   * @param {StateDatabaseConfig} stateDatabase
+   * @return {string}
+   */
+   static getDatabaseId(stateDatabase) {
+    let databaseId = stateDatabase.databaseId;
+    if (!databaseId) {
+      databaseId = "(default)";
+    }
+    return databaseId;
+  }
+
+  /**
    * Memoize createFirestoreClient() so that we only create one Firestore
    * client for each stateProject
    */
-  static getFirestoreClient = memoize(StateFirestore.createFirestoreClient);
+  static getFirestoreClient = memoize(
+    StateFirestore.createFirestoreClient, StateFirestore.getDatabaseId
+  );
 
   /**
    * @param {AutoscalerMemorystoreCluster} cluster

--- a/src/scaler/scaler-core/test/state.test.js
+++ b/src/scaler/scaler-core/test/state.test.js
@@ -127,6 +127,10 @@ describe('stateFirestoreTests', () => {
   /** @type {AutoscalerMemorystoreCluster} */
   const autoscalerConfig = {
     ...BASE_CONFIG,
+    stateDatabase: {
+      name: 'firestore',
+      databaseId: '(default)',
+    },
   };
 
   /** @type {firestore.DocumentSnapshot<any>} */


### PR DESCRIPTION
Update the firestore class to accept the databaseId.
- As the default the `@google-cloud/firestore` is using the `"(default)"` named firestore database if we don't set databaseId field.
- Set the default database Id as `"(default)"` explicitly when there are no databaseId field originated from the cluster.stateDatabase configuration.