### PR TITLE
feat!: remove App Engine, add Firestore configurability

### DIFF
--- a/src/poller/README.md
+++ b/src/poller/README.md
@@ -209,6 +209,14 @@ for managing the state of the Autoscaler.
 | -------------------------- | ------------ | ----------- |
 | `name`                     | `firestore`  | Name of the database for managing the state of the Autoscaler. By default, Firestore is used. The currently supported values are `firestore` and `spanner`. |
 
+### State Management in Firestore
+
+If the value of `name` is `firestore`, the following values are optional.
+
+| Key                        | Description |
+| -------------------------- | ----------- |
+| `databaseId`               | The database ID of the Firestore database you want to use to store the autoscaler state. If omitted, the default (`(default)`) database will be used. Note that the database must exist. |
+
 ### State Management in Cloud Spanner
 
 If the value of `name` is `spanner`, the following values are required.

--- a/src/scaler/scaler-core/test/state.test.js
+++ b/src/scaler/scaler-core/test/state.test.js
@@ -171,7 +171,49 @@ describe('stateFirestoreTests', () => {
     delete config.stateProjectId;
     const state = State.buildFor(config);
     assert.equals(state.constructor.name, 'StateFirestore');
-    sinon.assert.calledWith(stubFirestoreConstructor, {projectId: 'myProject'});
+    sinon.assert.calledWith(stubFirestoreConstructor, {
+      projectId: 'myProject',
+      databaseId: '(default)',
+    });
+  });
+
+  it('should create a StateFirestore object with custom config', function () {
+    const databaseConfig = {
+      stateDatabase: {
+        name: 'firestore',
+      },
+    };
+    const config = {
+      ...autoscalerConfig,
+      ...databaseConfig,
+    };
+    delete config.stateProjectId;
+    const state = State.buildFor(config);
+    assert.equals(state.constructor.name, 'StateFirestore');
+    sinon.assert.calledWith(stubFirestoreConstructor, {
+      projectId: 'myProject',
+      databaseId: '(default)',
+    });
+  });
+
+  it('should create a StateFirestore object with a custom db', function () {
+    const databaseConfig = {
+      stateDatabase: {
+        name: 'firestore',
+        databaseId: 'myDatabase',
+      },
+    };
+    const config = {
+      ...autoscalerConfig,
+      ...databaseConfig,
+    };
+    delete config.stateProjectId;
+    const state = State.buildFor(config);
+    assert.equals(state.constructor.name, 'StateFirestore');
+    sinon.assert.calledWith(stubFirestoreConstructor, {
+      projectId: 'myProject',
+      databaseId: 'myDatabase',
+    });
   });
 
   it('should create a StateFirestore object connecting to stateProjectId', function () {
@@ -179,6 +221,7 @@ describe('stateFirestoreTests', () => {
     assert.equals(state.constructor.name, 'StateFirestore');
     sinon.assert.calledWith(stubFirestoreConstructor, {
       projectId: 'stateProject',
+      databaseId: '(default)',
     });
   });
 
@@ -203,9 +246,11 @@ describe('stateFirestoreTests', () => {
     assert.equals(calls.length, 2);
     assert.equals(calls[0].args[0], {
       projectId: 'stateProject1',
+      databaseId: '(default)',
     });
     assert.equals(calls[1].args[0], {
       projectId: 'stateProject2',
+      databaseId: '(default)',
     });
   });
 

--- a/terraform/cloud-functions/distributed/README.md
+++ b/terraform/cloud-functions/distributed/README.md
@@ -144,7 +144,7 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
     project:
 
     ```sh
-    export AUTOSCALER_PROJECT_ID=<INSERT_YOUR_PROJECT_ID>
+    export AUTOSCALER_PROJECT_ID=<YOUR_PROJECT_ID>
     gcloud config set project "${AUTOSCALER_PROJECT_ID}"
     ```
 
@@ -159,7 +159,6 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
 
     ```sh
     gcloud services enable \
-        appengine.googleapis.com \
         artifactregistry.googleapis.com \
         cloudbuild.googleapis.com \
         cloudfunctions.googleapis.com \
@@ -186,26 +185,23 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
 
 ### Using Firestore for Autoscaler state
 
-1.  To use Firestore for the Autoscaler state, enable the additional APIs:
+1.  To use Firestore for the Autoscaler state, enable the additional API:
 
     ```sh
     gcloud services enable firestore.googleapis.com
     ```
 
-2.  Create a Google App Engine app to enable the API for Firestore:
+2.  If you want to choose the name for your Firestore database, set the
+    following variable:
 
     ```sh
-    gcloud app create --region="${REGION}"
+    export TF_VAR_firestore_state_database=<DATABASE_NAME>
     ```
 
-3.  To store the state of the Autoscaler, update the database created with the
-    Google App Engine app to use [Firestore native mode][firestore-native].
+    If you do not set this variable, the default database will be used
+    (`(default)`).
 
-    ```sh
-    gcloud firestore databases update --type=firestore-native
-    ```
-
-4.  Next, continue to [Deploying the Autoscaler](#deploying-the-autoscaler).
+3.  Next, continue to [Deploying the Autoscaler](#deploying-the-autoscaler).
 
 ### Using Spanner for Autoscaler state
 
@@ -227,7 +223,7 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
     set the the name of your instance:
 
     ```sh
-    export TF_VAR_spanner_state_name=<INSERT_YOUR_STATE_SPANNER_INSTANCE_NAME>
+    export TF_VAR_spanner_state_name=<SPANNER_INSTANCE_NAME>
     ```
 
     If you want to manage the state of the Autoscaler in your own
@@ -309,7 +305,6 @@ topic and function in the project where the Memorystore Cluster instances live.
 
     ```sh
     gcloud services enable \
-        appengine.googleapis.com \
         artifactregistry.googleapis.com \
         cloudbuild.googleapis.com \
         cloudfunctions.googleapis.com \
@@ -327,16 +322,9 @@ topic and function in the project where the Memorystore Cluster instances live.
         serviceconsumermanagement.googleapis.com
     ```
 
-6.  Create an App to enable Cloud Scheduler, but do not create a Firestore
-    database:
-
-    ```sh
-    gcloud app create --region="${APP_REGION}"
-    ```
-
 ### Deploy the Application infrastructure
 
-1.  Set the project ID, region, and App Engine location in the
+1.  Set the project ID and region in the
     corresponding Terraform environment variables
 
     ```sh
@@ -442,7 +430,6 @@ its configuration issues independently.
 [cloud-shell]: https://console.cloud.google.com/?cloudshell=true
 [cloud-spanner]: https://cloud.google.com/spanner
 [enable-billing]: https://cloud.google.com/billing/docs/how-to/modify-project
-[firestore-native]: https://cloud.google.com/datastore/docs/firestore-or-datastore#in_native_mode
 [logs-viewer]: https://console.cloud.google.com/logs/query
 [project-selector]: https://console.cloud.google.com/projectselector2/home/dashboard
 [provider-issue]: https://github.com/hashicorp/terraform-provider-google/issues/6782

--- a/terraform/cloud-functions/distributed/app-project/main.tf
+++ b/terraform/cloud-functions/distributed/app-project/main.tf
@@ -97,9 +97,10 @@ module "autoscaler-scheduler" {
   pubsub_topic             = module.autoscaler-forwarder.forwarder_topic
   target_pubsub_topic      = data.terraform_remote_state.autoscaler.outputs.scaler_topic
 
-  terraform_spanner_state = var.terraform_spanner_state
-  spanner_state_name      = var.spanner_state_name
-  spanner_state_database  = var.spanner_state_database
+  terraform_spanner_state  = var.terraform_spanner_state
+  spanner_state_name       = var.spanner_state_name
+  spanner_state_database   = var.spanner_state_database
+  firestore_state_database = var.firestore_state_database
 
   // Example of passing config as json
   // json_config             = base64encode(jsonencode([{

--- a/terraform/cloud-functions/distributed/app-project/variables.tf
+++ b/terraform/cloud-functions/distributed/app-project/variables.tf
@@ -69,6 +69,11 @@ variable "spanner_state_database" {
   default = "memorystore-autoscaler-state"
 }
 
+variable "firestore_state_database" {
+  type    = string
+  default = "memorystore-autoscaler-state"
+}
+
 variable "terraform_test_vm" {
   description = "If set to true, Terraform will create a test VM with Memorystore utils installed."
   type        = bool

--- a/terraform/cloud-functions/distributed/autoscaler-project/main.tf
+++ b/terraform/cloud-functions/distributed/autoscaler-project/main.tf
@@ -59,9 +59,13 @@ module "autoscaler-functions" {
 }
 
 module "firestore" {
+  count  = !var.terraform_spanner_state ? 1 : 0
   source = "../../../modules/autoscaler-firestore"
 
-  project_id      = var.project_id
+  project_id               = var.project_id
+  region                   = var.region
+  firestore_state_database = var.firestore_state_database
+
   poller_sa_email = google_service_account.poller_sa.email
   scaler_sa_email = google_service_account.scaler_sa.email
 }

--- a/terraform/cloud-functions/distributed/autoscaler-project/variables.tf
+++ b/terraform/cloud-functions/distributed/autoscaler-project/variables.tf
@@ -44,6 +44,11 @@ variable "spanner_state_database" {
   default = "memorystore-autoscaler-state"
 }
 
+variable "firestore_state_database" {
+  type    = string
+  default = "memorystore-autoscaler-state"
+}
+
 variable "terraform_dashboard" {
   description = "If set to true, Terraform will create a Cloud Monitoring dashboard including important Spanner metrics."
   type        = bool

--- a/terraform/cloud-functions/per-project/README.md
+++ b/terraform/cloud-functions/per-project/README.md
@@ -137,13 +137,12 @@ In this section you prepare your project for deployment.
     project:
 
     ```sh
-    export PROJECT_ID=<INSERT_YOUR_PROJECT_ID>
+    export PROJECT_ID=<YOUR_PROJECT_ID>
     gcloud config set project "${PROJECT_ID}"
     ```
 
-4.  Choose the [region][region-and-zone] and
-    [App Engine Location][app-engine-location] where the Autoscaler
-    infrastructure will be located.
+4.  Choose the [region][region-and-zone] where the Autoscaler infrastructure
+    will be located.
 
     ```sh
     export REGION=us-central1
@@ -153,7 +152,7 @@ In this section you prepare your project for deployment.
 
     ```sh
     gcloud services enable \
-      appengine.googleapis.com \
+      artifactregistry.googleapis.com \
       cloudbuild.googleapis.com \
       cloudfunctions.googleapis.com \
       cloudresourcemanager.googleapis.com \
@@ -181,26 +180,23 @@ In this section you prepare your project for deployment.
 
 ### Using Firestore for Autoscaler state
 
-1.  To use Firestore for the Autoscaler state, enable the additional APIs:
+1.  To use Firestore for the Autoscaler state, enable the additional API:
 
     ```sh
     gcloud services enable firestore.googleapis.com
     ```
 
-2.  Create a Google App Engine app to enable the API for Firestore:
+2.  If you want to choose the name for your Firestore database, set the
+    following variable:
 
     ```sh
-    gcloud app create --region="${REGION}"
+    export TF_VAR_firestore_state_database=<DATABASE_NAME>
     ```
 
-3.  To store the state of the Autoscaler, update the database created with the
-    Google App Engine app to use [Firestore native mode][firestore-native].
+    If you do not set this variable, the default database will be used
+    (`(default)`).
 
-    ```sh
-    gcloud firestore databases update --type=firestore-native
-    ```
-
-4.  Next, continue to [Deploying the Autoscaler](#deploying-the-autoscaler).
+3.  Next, continue to [Deploying the Autoscaler](#deploying-the-autoscaler).
 
 ### Using Spanner for Autoscaler state
 
@@ -222,7 +218,7 @@ In this section you prepare your project for deployment.
     set the the name of your instance:
 
     ```sh
-    export TF_VAR_spanner_state_name=<INSERT_YOUR_STATE_SPANNER_INSTANCE_NAME>
+    export TF_VAR_spanner_state_name=<SPANNER_INSTANCE_NAME>
     ```
 
     If you want to manage the state of the Autoscaler in your own
@@ -292,13 +288,7 @@ In this section you prepare your project for deployment.
     terraform init
     ```
 
-5.  Import the existing App Engine application into Terraform state:
-
-    ```sh
-    terraform import module.autoscaler-scheduler.google_app_engine_application.app "${PROJECT_ID}"
-    ```
-
-6.  Create the Autoscaler infrastructure. Answer `yes` when prompted, after
+5.  Create the Autoscaler infrastructure. Answer `yes` when prompted, after
     reviewing the resources that Terraform intends to create.
 
     ```sh
@@ -377,13 +367,11 @@ page to [configure your Autoscaler](../README.md#configuration).
 
 <!-- LINKS: https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 
-[app-engine-location]: https://cloud.google.com/appengine/docs/locations
 [cloud-console]: https://console.cloud.google.com
 [cloud-firestore]: https://cloud.google.com/firestore
 [cloud-shell]: https://console.cloud.google.com/?cloudshell=true
 [cloud-spanner]: https://cloud.google.com/spanner
 [enable-billing]: https://cloud.google.com/billing/docs/how-to/modify-project
-[firestore-native]: https://cloud.google.com/datastore/docs/firestore-or-datastore#in_native_mode
 [iap]: https://cloud.google.com/security/products/iap
 [project-selector]: https://console.cloud.google.com/projectselector2/home/dashboard
 [provider-issue]: https://github.com/hashicorp/terraform-provider-google/issues/6782

--- a/terraform/cloud-functions/per-project/main.tf
+++ b/terraform/cloud-functions/per-project/main.tf
@@ -58,9 +58,13 @@ module "autoscaler-functions" {
 }
 
 module "autoscaler-firestore" {
+  count  = !var.terraform_spanner_state ? 1 : 0
   source = "../../modules/autoscaler-firestore"
 
-  project_id      = local.app_project_id
+  project_id               = local.app_project_id
+  region                   = var.region
+  firestore_state_database = var.firestore_state_database
+
   poller_sa_email = google_service_account.poller_sa.email
   scaler_sa_email = google_service_account.scaler_sa.email
 }
@@ -87,9 +91,10 @@ module "autoscaler-scheduler" {
   pubsub_topic             = module.autoscaler-functions.poller_topic
   target_pubsub_topic      = module.autoscaler-functions.scaler_topic
 
-  terraform_spanner_state = var.terraform_spanner_state
-  spanner_state_name      = var.spanner_state_name
-  spanner_state_database  = var.spanner_state_database
+  terraform_spanner_state  = var.terraform_spanner_state
+  spanner_state_name       = var.spanner_state_name
+  spanner_state_database   = var.spanner_state_database
+  firestore_state_database = var.firestore_state_database
 
   // Example of passing config as json
   // json_config             = base64encode(jsonencode([{

--- a/terraform/cloud-functions/per-project/test/per_project_e2e_test.go
+++ b/terraform/cloud-functions/per-project/test/per_project_e2e_test.go
@@ -168,14 +168,6 @@ func TestPerProjectEndToEndDeployment(t *testing.T) {
 		logger.Log(t, "TEST STAGE: TEARDOWN COMPLETED")
 	})
 
-	test_structure.RunTestStage(t, "import", func() {
-		terraformOptions := test_structure.LoadTerraformOptions(t, terraformDir)
-		terraformArgs := []string{"module.autoscaler-scheduler.google_app_engine_application.app", config.ProjectId}
-		terraformArgsFormatted := append(terraform.FormatArgs(terraformOptions, "-input=false"), terraformArgs...)
-		terraformCommand := append([]string{"import"}, terraformArgsFormatted...)
-		terraform.RunTerraformCommand(t, terraformOptions, terraformCommand...)
-	})
-
 	test_structure.RunTestStage(t, "apply", func() {
 		logger.Log(t, "TEST STAGE: TERRAFORM APPLY")
 		logger.Log(t, "----------------------------------------------------------")

--- a/terraform/cloud-functions/per-project/variables.tf
+++ b/terraform/cloud-functions/per-project/variables.tf
@@ -65,6 +65,11 @@ variable "spanner_state_database" {
   default = "memorystore-autoscaler-state"
 }
 
+variable "firestore_state_database" {
+  type    = string
+  default = "memorystore-autoscaler-state"
+}
+
 variable "terraform_test_vm" {
   description = "If set to true, Terraform will create a test VM with Memorystore utils installed."
   type        = bool

--- a/terraform/gke/README.md
+++ b/terraform/gke/README.md
@@ -167,7 +167,7 @@ In this section you prepare your project for deployment.
     **autoscaler** project:
 
     ```sh
-    export PROJECT_ID=<INSERT_YOUR_PROJECT_ID>
+    export PROJECT_ID=<YOUR_PROJECT_ID>
     gcloud config set project ${PROJECT_ID}
     ```
 
@@ -206,32 +206,27 @@ In this section you prepare your project for deployment.
 
 ### Using Firestore for Autoscaler state
 
-1.  To use Firestore for the Autoscaler state, enable the additional APIs:
+1.  To use Firestore for the Autoscaler state, enable the additional API:
 
     ```sh
-    gcloud services enable \
-      appengine.googleapis.com \
-      firestore.googleapis.com
+    gcloud services enable firestore.googleapis.com
     ```
 
-2.  Create a Google App Engine app to enable the API for Firestore:
+2.  If you want to choose the name for your Firestore database, set the
+    following variable:
 
     ```sh
-    gcloud app create --region="${REGION}"
+    export TF_VAR_firestore_state_database=<DATABASE_NAME>
     ```
 
-3.  To store the state of the Autoscaler, update the database created with the
-    Google App Engine app to use [Firestore native mode][firestore-native].
-
-    ```sh
-    gcloud firestore databases update --type=firestore-native
-    ```
+    If you do not set this variable, the default database will be used
+    (`(default)`).
 
     You will also need to make a minor modification to the Autoscaler
     configuration. The required steps to do this are later in these
     instructions.
 
-4.  Next, continue to [Creating Autoscaler infrastructure](#creating-autoscaler-infrastructure).
+3.  Next, continue to [Creating Autoscaler infrastructure](#creating-autoscaler-infrastructure).
 
 ### Using Spanner for Autoscaler state
 
@@ -253,7 +248,7 @@ In this section you prepare your project for deployment.
     set the the name of your instance:
 
     ```sh
-    export TF_VAR_spanner_state_name=<INSERT_YOUR_STATE_SPANNER_INSTANCE_NAME>
+    export TF_VAR_spanner_state_name=<SPANNER_INSTANCE_NAME>
     ```
 
     If you want to manage the state of the Autoscaler in your own
@@ -679,7 +674,6 @@ following the instructions above.
 [cloud-monitoring]: https://cloud.google.com/monitoring
 [cloud-shell]: https://console.cloud.google.com/?cloudshell=true
 [enable-billing]: https://cloud.google.com/billing/docs/how-to/modify-project
-[firestore-native]: https://cloud.google.com/datastore/docs/firestore-or-datastore#in_native_mode
 [gcm-docs]: https://cloud.google.com/monitoring/docs
 [gke]: https://cloud.google.com/kubernetes-engine
 [kubernetes-configmap]: https://kubernetes.io/docs/concepts/configuration/configmap/

--- a/terraform/gke/unified/main.tf
+++ b/terraform/gke/unified/main.tf
@@ -61,9 +61,13 @@ module "autoscaler-gke" {
 }
 
 module "autoscaler-firestore" {
+  count  = !var.terraform_spanner_state ? 1 : 0
   source = "../../modules/autoscaler-firestore"
 
-  project_id      = var.project_id
+  project_id               = var.project_id
+  region                   = var.region
+  firestore_state_database = var.firestore_state_database
+
   poller_sa_email = google_service_account.autoscaler_sa.email
   scaler_sa_email = google_service_account.autoscaler_sa.email
 }

--- a/terraform/gke/unified/variables.tf
+++ b/terraform/gke/unified/variables.tf
@@ -59,6 +59,11 @@ variable "spanner_state_database" {
   default = "memorystore-autoscaler-state"
 }
 
+variable "firestore_state_database" {
+  type    = string
+  default = "memorystore-autoscaler-state"
+}
+
 variable "terraform_test_vm" {
   description = "If set to true, Terraform will create a test VM with Memorystore utils installed."
   type        = bool

--- a/terraform/modules/autoscaler-firestore/main.tf
+++ b/terraform/modules/autoscaler-firestore/main.tf
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-/*
- * While the Firestore database is created using the gcloud CLI, the
- * Terraform-created service account used by the Scaler needs read/write
- * permissions to the instance in the appropriate project if Spanner
- * is not being used to hold state.
- */
-
 resource "google_project_iam_member" "scaler_sa_firestore" {
-
   project = var.project_id
   role    = "roles/datastore.user"
   member  = "serviceAccount:${var.scaler_sa_email}"
+}
+
+resource "google_firestore_database" "database" {
+  project                     = var.project_id
+  name                        = var.firestore_state_database
+  location_id                 = var.region
+  type                        = "FIRESTORE_NATIVE"
+  app_engine_integration_mode = "DISABLED"
+  delete_protection_state     = "DELETE_PROTECTION_DISABLED"
+  deletion_policy             = "DELETE"
 }

--- a/terraform/modules/autoscaler-firestore/variables.tf
+++ b/terraform/modules/autoscaler-firestore/variables.tf
@@ -18,10 +18,18 @@ variable "project_id" {
   type = string
 }
 
+variable "region" {
+  type = string
+}
+
 variable "poller_sa_email" {
   type = string
 }
 
 variable "scaler_sa_email" {
+  type = string
+}
+
+variable "firestore_state_database" {
   type = string
 }

--- a/terraform/modules/autoscaler-scheduler/main.tf
+++ b/terraform/modules/autoscaler-scheduler/main.tf
@@ -32,17 +32,13 @@ locals {
         "databaseId" : "${var.spanner_state_database}",
         } : {
         "name" : "firestore",
+        "databaseId" : "${var.firestore_state_database}"
       }
       },
       var.state_project_id != null ? {
         "stateProjectId" : "${var.state_project_id}"
     } : {})
   ]))
-}
-
-resource "google_app_engine_application" "app" {
-  project     = var.project_id
-  location_id = var.location == "us-central1" ? "us-central" : var.location
 }
 
 resource "google_cloud_scheduler_job" "poller_job" {
@@ -63,8 +59,6 @@ resource "google_cloud_scheduler_job" "poller_job" {
     max_doublings        = 5
     min_backoff_duration = "5s"
   }
-
-  depends_on = [google_app_engine_application.app]
 
   /**
    * Uncomment this stanza if you would prefer to manage the Cloud Scheduler

--- a/terraform/modules/autoscaler-scheduler/variables.tf
+++ b/terraform/modules/autoscaler-scheduler/variables.tf
@@ -92,6 +92,10 @@ variable "spanner_state_database" {
   default  = null
 }
 
+variable "firestore_state_database" {
+  type = string
+}
+
 variable "state_project_id" {
   type     = string
   nullable = true


### PR DESCRIPTION
BREAKING CHANGE: Because this modifies the requirements for how a project must be configured, this is considered a breaking change as it cannot be exhaustively tested across all combinations of projects and Terraform provider versions.