### PR TITLE
chore: restrict SSH to IAP source range

### DIFF
--- a/terraform/modules/autoscaler-test-vm/main.tf
+++ b/terraform/modules/autoscaler-test-vm/main.tf
@@ -70,8 +70,8 @@ resource "google_compute_firewall" "rules" {
   project       = var.project_id
   network       = var.network
   name          = "ssh"
-  description   = "Allow SSH from anywhere"
-  source_ranges = ["0.0.0.0/0"]
+  description   = "Allow SSH from Identity-Aware Proxy"
+  source_ranges = ["35.235.240.0/20"]
   allow {
     protocol = "tcp"
     ports    = ["22"]


### PR DESCRIPTION
The test VM has no external IP, but even so for completeness we can further restrict ssh access by limiting to the IAP source range:

https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule