### PR TITLE
ci: configure Dependabot to open PRs for security updates only

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,6 +21,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "fix"
+    # Use Renovate for version updates, Dependabot for security updates only:
+    open-pull-requests-limit: 0
 
   # NPM dependencies -- only prompt to update minor versions.
   - directory: "/"
@@ -32,6 +34,8 @@ updates:
         update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "fix"
+    # Use Renovate for version updates, Dependabot for security updates only:
+    open-pull-requests-limit: 0
 
   # Docker dependencies
   - directory: "/"
@@ -40,6 +44,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "fix"
+    # Use Renovate for version updates, Dependabot for security updates only:
+    open-pull-requests-limit: 0
 
   # Terraform dependencies
   - directory: "/terraform"
@@ -48,5 +54,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "fix"
+    # Use Renovate for version updates, Dependabot for security updates only:
+    open-pull-requests-limit: 0
 
 version: 2


### PR DESCRIPTION
Renovate is used for regular (non-security) version updates.