### PR TITLE
docs: propagate note on Firestore database name

### DIFF
--- a/terraform/cloud-functions/distributed/README.md
+++ b/terraform/cloud-functions/distributed/README.md
@@ -199,8 +199,9 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
     export TF_VAR_firestore_state_database=<DATABASE_NAME>
     ```
 
-    If you do not set this variable, the default database will be used
-    (`(default)`).
+    If you do not set this variable, Terraform will create and use a dedicated
+    Firestore database named `memorystore-autoscaler-state` for storing
+    Autoscaler state.
 
 3.  Next, continue to [Deploying the Autoscaler](#deploying-the-autoscaler).
 

--- a/terraform/cloud-functions/per-project/README.md
+++ b/terraform/cloud-functions/per-project/README.md
@@ -194,8 +194,9 @@ In this section you prepare your project for deployment.
     export TF_VAR_firestore_state_database=<DATABASE_NAME>
     ```
 
-    If you do not set this variable, the default database will be used
-    (`(default)`).
+    If you do not set this variable, Terraform will create and use a dedicated
+    Firestore database named `memorystore-autoscaler-state` for storing
+    Autoscaler state.
 
 3.  Next, continue to [Deploying the Autoscaler](#deploying-the-autoscaler).
 


### PR DESCRIPTION
This is in addition to the note for GKE added in #74.