### PR TITLE
Update to README.md

### DIFF
--- a/terraform/cloud-functions/per-project/README.md
+++ b/terraform/cloud-functions/per-project/README.md
@@ -181,7 +181,7 @@ In this section you prepare your project for deployment.
     the following variable:
 
     ```sh
-    export TF_VAR_memorystore_engine=valkey
+    export TF_VAR_memorystore_engine=VALKEY
     ```
 
 7.  There are two options for deploying the state store for the Autoscaler:


### PR DESCRIPTION
fix(docs): correct casing for VALKEY engine variable in Readme

The `TF_VAR_memorystore_engine` variable requires the engine name to be in all capital letters (e.g., VALKEY).

The previous example in Readme.md used a lowercase value, which causes the `terraform apply` command to fail. This commit updates the documentation to use the correct casing.